### PR TITLE
Add JS tests

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -2,8 +2,23 @@ srcdir = "src"
 
 import ospaths
 
-proc buildBase(debug: bool, bin: string, src: string) =
-  switch("out", (thisDir() & "/" & bin).toExe)
+type Target {.pure.} = enum JS, C
+
+template dep(task: untyped): stmt =
+  exec "nim " & astToStr(task)
+
+template deps(a, b: untyped): stmt =
+  dep(a)
+  dep(b)
+
+proc buildBase(debug: bool, bin: string, src: string, target: Target) =
+  let baseBinPath = thisDir() / bin
+  case target
+  of Target.C:
+    switch("out", baseBinPath.toExe)
+  of Target.JS:
+    switch("out", baseBinPath & ".js")
+
   --nimcache: build
   if not debug:
     --forceBuild
@@ -23,14 +38,25 @@ proc buildBase(debug: bool, bin: string, src: string) =
     --NimblePath: src
     --NimblePath: srcdir
     
-  setCommand "c", src
+  case target
+  of Target.C:
+    setCommand "c", src
+  of Target.JS:
+    setCommand "js", src
 
-proc test(name: string) =
+proc test(name: string, target: Target) =
   if not dirExists "bin":
     mkDir "bin"
   --run
   let fName = name.splitPath[1]
-  buildBase true, joinPath("bin", fName), joinPath("tests/boost", name)
+  buildBase true, joinPath("bin", fName), joinPath("tests/boost", name), target
+
+task test_c, "Run all tests (C)":
+  test "test_all", Target.C
+
+task test_js, "Run all tests (JS)":
+  test "test_js", Target.JS
 
 task test, "Run all tests":
-  test "test_all"
+  deps test_c, test_js
+  setCommand "nop"

--- a/config.nims
+++ b/config.nims
@@ -42,6 +42,7 @@ proc buildBase(debug: bool, bin: string, src: string, target: Target) =
   of Target.C:
     setCommand "c", src
   of Target.JS:
+    switch("d", "nodeJs")
     setCommand "js", src
 
 proc test(name: string, target: Target) =

--- a/tests/boost/test_js.nim
+++ b/tests/boost/test_js.nim
@@ -1,3 +1,3 @@
-import data.test_stackm, data.test_rbtreem, data.test_rbtree
+import test_typeclasses, data.test_stackm, data.test_rbtreem, data.test_rbtree
 # TODO: fix these for JS
-# import test_typeclasses, test_limits, test_parsers
+# import test_limits, test_parsers

--- a/tests/boost/test_js.nim
+++ b/tests/boost/test_js.nim
@@ -1,3 +1,3 @@
-import test_typeclasses, data.test_stackm, data.test_rbtreem, data.test_rbtree
+import data.test_stackm, data.test_rbtreem, data.test_rbtree
 # TODO: fix these for JS
-import test_limits, test_parsers
+# import test_typeclasses, test_limits, test_parsers

--- a/tests/boost/test_js.nim
+++ b/tests/boost/test_js.nim
@@ -1,0 +1,3 @@
+import test_typeclasses, data.test_stackm, data.test_rbtreem, data.test_rbtree
+# TODO: fix these for JS
+import test_limits, test_parsers


### PR DESCRIPTION
Right now only `test_typeclasses`, `test_stackm`, `test_rbtreem`, `test_rbtree` work with JS.
`test_limits` and `test_parsers` are temporary disabled (until the corresponding modules are fixed).
