### PR TITLE
Http improvements

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -143,6 +143,9 @@ task test_asyncstreams_no_net, "Test asyncstreams without networking":
   --d: noNet
   test "io/test_asyncstreams", Target.C
 
+task test_asyncchunkedstream, "Test AsyncChunkedStream":
+  test "http/test_asyncchunkedstream", Target.C
+
 task test_multipart, "Test multipart":
   test "http/test_multipart", Target.C
 

--- a/src/boost/http/asyncchunkedstream.nim
+++ b/src/boost/http/asyncchunkedstream.nim
@@ -1,9 +1,8 @@
 import strutils, asyncdispatch
 import ../io/asyncstreams
+import ./httpcommon
 
 type
-  MalformedChunkedStreamError* = object of IOError
-
   # Possible states of the stream:
   # 1. Beginning of a chunk (bytesLeft = 0).
   #    Underlying stream will next read the first byte of the next chunk size.
@@ -39,7 +38,7 @@ proc cAtEnd(s: AsyncStream): bool =
 
 proc raiseError(s: AsyncChunkedStream, msg: string) {.noReturn.} =
   s.state = sFailed
-  raise newException(MalformedChunkedStreamError, msg)
+  raise newException(MalformedHttpException, msg)
 
 proc readExactly(s: AsyncChunkedStream, size: Natural): Future[string] {.async.} =
   var res = newString(size)
@@ -151,7 +150,7 @@ proc newAsyncChunkedStream*(src: AsyncStream): AsyncChunkedStream =
   ## message body. Closing the underlying stream is handled by caller to allow
   ## continuing HTTP connection.
   ##
-  ## Decoded stream can throw a `MalformedChunkedStreamError` exception when
+  ## Decoded stream can throw a `MalformedHttpException` when
   ## reading or closing to signal unexpected data in the underlying stream.
   ##
   ## *Warning*: Discarding or closing the chunked stream before it reaches the

--- a/src/boost/http/asyncchunkedstream.nim
+++ b/src/boost/http/asyncchunkedstream.nim
@@ -1,0 +1,168 @@
+import strutils, asyncdispatch
+import ../io/asyncstreams
+
+type
+  MalformedChunkedStreamError* = object of IOError
+
+  # Possible states of the stream:
+  # 1. Beginning of a chunk (bytesLeft = 0).
+  #    Underlying stream will next read the first byte of the next chunk size.
+  # 2. Middle of a chunk (bytesLeft > 0).
+  #    Underlying stream will next read one of the bytes of chunk data.
+  # 3. EOF. No more data to read
+  # 4. Closed.
+  State = enum sBeginning, sMiddle, sEOF, sFailed, sClosed
+  AsyncChunkedStream* = ref AsyncChunkedStreamObj
+    ## Asynchronous chunked stream.
+    ##
+    ## Decodes the underlying stream from `Transfer-Encoding: chunked`.
+    ##
+  AsyncChunkedStreamObj* = object of AsyncStreamObj
+    ## Asynchronous chunked stream.
+    src: AsyncStream
+    state: State
+    bytesLeft: Natural # until the end of the current chunk
+
+proc isFailed*(s: AsyncChunkedStream): bool =
+  ## Returns `true` if parsing the message body has failed.
+  s.state == sFailed
+
+proc cClose(s: AsyncStream) =
+  if s.AsyncChunkedStream.state in {sBeginning, sMiddle, sEOF, sFailed}:
+    s.AsyncChunkedStream.src.close
+
+  # Make sure not to lose `sFailed` state
+  s.AsyncChunkedStream.state = min(sClosed, s.AsyncChunkedStream.state)
+
+proc cAtEnd(s: AsyncStream): bool =
+  s.AsyncChunkedStream.state in {sEOF, sClosed, sFailed}
+
+proc raiseError(s: AsyncChunkedStream, msg: string) {.noReturn.} =
+  s.state = sFailed
+  raise newException(MalformedChunkedStreamError, msg)
+
+proc readExactly(s: AsyncChunkedStream, size: Natural): Future[string] {.async.} =
+  var res = newString(size)
+  var pos = 0
+  while pos < size:
+    let bytesRead = await s.src.readBuffer(addr(res[pos]), size - pos)
+    if bytesRead <= 0: raiseError(s, "unexpected EOF")
+    pos.inc(bytesRead)
+  return res
+
+proc readExpected(
+  s: AsyncChunkedStream,
+  expected: string,
+  description: string = nil
+): Future[void] {.async.} =
+  let got = await s.readExactly(expected.len)
+  if expected != got:
+    let effectiveDesc = if description.isNil: escape(expected) else: description
+    raiseError(s, effectiveDesc & " expected, got " & escape(got))
+
+proc readHttpLine(s: AsyncChunkedStream): Future[string] {.async.} =
+  ## Like `src.readLine`, but the line must terminate in `"\c\l"`. The ending
+  ## sequence itself is not a part of the resulting string. `'\0'` in the line
+  ## is allowed.
+  var res = ""
+  while true:
+    let c = await s.src.readChar
+    if c == '\c':
+      await s.readExpected("\L")
+      # Found newline
+      break
+    elif c == '\L':
+      raiseError(s, "unexpected \\L")
+    elif c == '\0' and s.src.atEnd:
+      raiseError(s, "unexpected EOF")
+    else:
+      res.add(c)
+
+  return res
+
+proc readNewline(s: AsyncChunkedStream): Future[void] {.async.} =
+  await s.readExpected("\c\l")
+
+proc readSizeAndExtensions(s: AsyncChunkedStream): Future[Natural] {.async.} =
+  let line = await s.readHttpLine
+  let sepPos = line.find(';')
+  let sub =
+    if sepPos == -1: line
+    else: line[0..<sepPos]
+
+  var res: int
+  try:
+    # TODO: don't allow hex prefices
+    res = parseHexInt(sub)
+    if res < 0: s.raiseError("invalid chunk size: " & escape(sub))
+  except ValueError:
+    s.raiseError("invalid chunk size: " & escape(sub))
+
+  return res.Natural
+
+proc readTrailer(s: AsyncChunkedStream): Future[void] {.async.} =
+  while (await s.readHttpLine) != "": discard
+
+proc cRead(s0: AsyncStream, buf: pointer, bufLen: int): Future[int] {.async.} =
+  let s = s0.AsyncChunkedStream
+  if bufLen <= 0 or s.state in {sEOF, sClosed}: return 0
+  if s.state == sFailed: s.raiseError("Malformed message body")
+
+  if s.state == sBeginning:
+    s.bytesLeft = await readSizeAndExtensions(s)
+
+    if s.bytesLeft == 0:
+      # The last part
+      await readTrailer(s)
+      s.state = sEOF
+      return 0
+    else:
+      s.state = sMiddle
+
+  # We're in the middle of a nonempty chunk
+  let bytesToRead = min(bufLen, s.bytesLeft)
+  let bytesRead = await s.src.readBuffer(buf, bytesToRead)
+  if bytesRead <= 0:
+    s.raiseError("unexpected EOF")
+  # This also proves that `bytesRead <= s.bytesLeft`
+  if bytesRead > bytesToRead:
+    s.raiseError("read more bytes than requested")
+
+  s.bytesLeft -= bytesRead
+
+  if s.bytesLeft == 0:
+    # We're at the end of a non-empty chunk - read up to the next one
+    await readNewline(s)
+    s.state = sBeginning
+  else:
+    # We're still in the middle
+    s.state = sMiddle
+
+  return bytesRead
+
+proc newAsyncChunkedStream*(src: AsyncStream): AsyncChunkedStream =
+  ## Create a new chunked stream wrapper.
+  ##
+  ## Decodes `Transfer-Encoding: chunked` message body in the underlying stream.
+  ##
+  ## The underlying stream must be at the first byte of the first chunk's size.
+  ## Unless an error is raised, after reading all the data from decoded stream
+  ## the underlying stream is positioned at the first byte after the decoded
+  ## message body. Closing the underlying stream is handled by caller to allow
+  ## continuing HTTP connection.
+  ##
+  ## Decoded stream can throw a `MalformedChunkedStreamError` exception when
+  ## reading or closing to signal unexpected data in the underlying stream.
+  ##
+  ## *Warning*: Discarding or closing the chunked stream before it reaches the
+  ## end will leave the underlying connection in the middle of the message body,
+  ## rendering it unusable.
+  new result
+  result.src = src
+  result.state = sBeginning
+  result.bytesLeft = 0
+  # TODO: these casts are ugly. Does it even make sense to have effect tracking
+  # for async procs, if they have `RootEffect` by default?
+  result.closeImpl = cast[type(result.closeImpl)](cClose)
+  result.atEndImpl = cast[type(result.atEndImpl)](cAtEnd)
+  result.readImpl = cast[type(result.readImpl)](cRead)

--- a/src/boost/http/asynchttpserver.nim
+++ b/src/boost/http/asynchttpserver.nim
@@ -25,7 +25,9 @@
 ##
 ##    waitFor server.serve(Port(8080), cb)
 
-import tables, asyncnet, asyncdispatch, parseutils, uri, strutils, ../io/asyncstreams
+import tables, asyncnet, asyncdispatch, parseutils, uri, strutils, options
+import ../io/asyncstreams, ./asyncchunkedstream
+from ./httpcommon import MalformedHttpException
 import httpcore
 import logging, ../richstring
 
@@ -37,12 +39,18 @@ export httpcore except parseHeader
 # Also, maybe move `client` out of `Request` object and into the args for
 # the proc.
 type
-  RequestBody* = ref object
+  TransferEncoding = enum teDefault, teChunked
+  RequestBodyKind = enum rbkCached, rbkStreamed
+
+  RequestBody* = ref RequestBodyObj
+  RequestBodyObj = object
     ## The request body implemented as asynchronous stream
-    s: AsyncStream
-    length: int64
-    data: string
-    cachedStream: AsyncStream
+    case kind: RequestBodyKind
+    of rbkCached:
+      data: string
+    of rbkStreamed:
+      stream: AsyncStream
+      contentLength: Option[int64]
 
   Request* = object
     client*: AsyncSocket # TODO: Separate this into a Response object?
@@ -67,53 +75,90 @@ proc newAsyncHttpServer*(reuseAddr = true, reusePort = false): AsyncHttpServer =
   result.reuseAddr = reuseAddr
   result.reusePort = reusePort
 
-proc len*(body: RequestBody): int64 =
-  ## Returns the length of the body
-  body.length
+proc len*(body: RequestBody): Option[int64] =
+  ## Returns the length of the body if available, otherwise `-1`
+  case body.kind
+  of rbkCached: body.data.len.int64.some
+  of rbkStreamed: body.contentLength
 
 type
+  # A stream wrapper that reads at most `length` bytes from the underlying stream
   RequestBodyStream = ref RequestBodyStreamObj
   RequestBodyStreamObj = object of AsyncStreamObj
-    body: RequestBody
+    s: AsyncStream
+    length: int64
     pos: int64
 
-proc rbClose(s: AsyncStream) = s.RequestBodyStream.body.s.close
-proc rbAtEnd(s: AsyncStream): bool = s.RequestBodyStream.pos + 1 >= s.RequestBodyStream.body.length
+proc rbClose(s: AsyncStream) =
+  s.RequestBodyStream.s.close
+
+proc rbAtEnd(s: AsyncStream): bool =
+  s.RequestBodyStream.pos + 1 >= s.RequestBodyStream.length
 proc rbGetPosition(s: AsyncStream): int64 = s.RequestBodyStream.pos
 proc rbReadData(s: AsyncStream, buff: pointer, buffLen: int): Future[int] {.async.} =
   var ss = s.RequestBodyStream
-  let toRead = if ss.pos + buffLen > ss.body.length: ss.body.length - ss.pos else: buffLen
-  result = await ss.body.s.readBuffer(buff, toRead.int)
+  let toRead = if ss.pos + buffLen > ss.length: ss.length - ss.pos else: buffLen
+  # TODO: handle unexpected EOF somehow?
+  result = await ss.s.readBuffer(buff, toRead.int)
   ss.pos += result
+
+proc newRequestBodyStream(s: AsyncStream, length: int64): RequestBodyStream =
+  new result
+  result.s = s
+  result.length = length
+  result.pos = 0
+  result.closeImpl = rbClose
+  result.atEndImpl = rbAtEnd
+  result.getPositionImpl = rbGetPosition
+  result.readImpl = cast[type(result.readImpl)](rbReadData)
+
+proc newSizedRequestBody(s: AsyncStream, contentLength: int64): RequestBody =
+  RequestBody(
+    kind: rbkStreamed,
+    stream: newRequestBodyStream(s, contentLength),
+    contentLength: contentLength.some
+  )
+
+proc newChunkedRequestBody(s: AsyncStream): RequestBody =
+  RequestBody(
+    kind: rbkStreamed,
+    stream: newAsyncChunkedStream(s),
+    contentLength: none(int64)
+  )
+
+proc newEmptyRequestBody(): RequestBody =
+  RequestBody(kind: rbkCached, data: "")
+
+proc setBodyCache(body: RequestBody, data: string) =
+  body[] = RequestBodyObj(kind: rbkCached, data: data)
 
 proc getStream*(body: RequestBody): AsyncStream =
   ## Returns the request's body as asynchronous stream
-  if not body.data.isNil:
-    result = newAsyncStringStream(body.data)
-  elif not body.cachedStream.isNil:
-    result = body.cachedStream
-  else:
-    var rb = new RequestBodyStream
-    rb.body = body
-    rb.pos = 0
-    rb.closeImpl = rbClose
-    rb.atEndImpl = rbAtEnd
-    rb.getPositionImpl = rbGetPosition
-    rb.readImpl = cast[type(rb.readImpl)](rbReadData)
-
-    body.cachedStream = rb
-
-    result = rb
+  ##
+  ## The resulting stream can raise `boost.http.util.MalformedHttpException`
+  ## in case of malformed request.
+  case body.kind
+  of rbkCached:
+    return newAsyncStringStream(body.data)
+  of rbkStreamed:
+    return body.stream
 
 proc body*(request: Request): Future[string] {.async.} =
   ## Returns the body of the request as the string.
-  if request.reqBody.isNil:
-    result = ""
-  elif request.reqBody.data.isNil:
-    request.reqBody.data = await request.reqBody.getStream.readAll
-    result = request.reqBody.data
+  ##
+  ## The resulting future can raise `boost.http.util.MalformedHttpException`
+  ## in case of malformed request.
+
+  if request.reqBody.isNil: return ""
   else:
-    result = request.reqBody.data
+    case request.reqBody.kind
+    of rbkStreamed:
+      # this doesn't work if someone has already started reading the stream!
+      let data = await request.reqBody.getStream.readAll
+      request.reqBody.setBodyCache(data)
+      return request.reqBody.data
+    of rbkCached:
+      return request.reqBody.data
 
 proc addHeaders(msg: var string, headers: HttpHeaders) =
   for k, v in headers:
@@ -176,132 +221,196 @@ proc parseProtocol(protocol: string): tuple[orig: string, major, minor: int] =
 proc sendStatus(client: AsyncSocket, status: string): Future[void] =
   client.send("HTTP/1.1 " & status & "\c\L")
 
-proc processBody(client: AsyncSocket, length: int64): RequestBody =
-  new result
-  result.length = length
-  result.s = newAsyncSocketStream(client)
+proc processOneRequest(
+  client: AsyncSocket, address: string,
+  callback: proc (request: Request): Future[void] {.closure, gcsafe.}
+): Future[bool] {.async.} =
+  ## Receives and handles one request.
+  ##
+  ## Returns `true` if the connection can be reused.
+  ##
+  ## Any raised exceptions mean that the connection was left in invalid state,
+  ## and the calling code must not reuse it.
 
-proc processClient(client: AsyncSocket, address: string,
-                   callback: proc (request: Request):
-                      Future[void] {.closure, gcsafe.}) {.async.} =
   var request: Request
   request.url = initUri()
   request.headers = newHttpHeaders()
   var lineFut = newFutureVar[string]("asynchttpserver.processClient")
   lineFut.mget() = newStringOfCap(80)
 
-  while not client.isClosed:
-    # GET /path HTTP/1.1
-    # Header: val
-    # \n
-    request.headers.clear()
-    request.reqBody = nil
-    request.hostname.shallowCopy(address)
-    assert client != nil
-    request.client = client
+  # TODO: there a lot of places we `continue` in the middle of the request.
+  # TODO: continuing circumvents closing the connection
 
-    # We should skip empty lines before the request
-    # https://tools.ietf.org/html/rfc7230#section-3.5
-    while true:
-      lineFut.mget().setLen(0)
-      lineFut.clean()
-      await client.recvLineInto(lineFut) # TODO: Timeouts.
+  # GET /path HTTP/1.1
+  # Header: val
+  # \n
+  request.headers.clear()
+  request.reqBody = nil
+  request.hostname.shallowCopy(address)
+  assert client != nil
+  request.client = client
 
-      if lineFut.mget == "":
-        client.close()
-        return
+  proc fail(reason = "Bad Request"): Future[void] {.async.} =
+    await request.respond(Http400, reason)
+    if true: raise newException(MalformedHttpException, reason)
 
-      if lineFut.mget != "\c\L":
-        break
+  # We should skip empty lines before the request
+  # https://tools.ietf.org/html/rfc7230#section-3.5
+  while true:
+    lineFut.mget().setLen(0)
+    lineFut.clean()
+    await client.recvLineInto(lineFut) # TODO: Timeouts.
 
-    # First line - GET /path HTTP/1.1
-    var i = 0
-    for linePart in lineFut.mget.split(' '):
-      case i
-      of 0: request.reqMethod.shallowCopy(linePart.normalize)
-      of 1: parseUri(linePart, request.url)
-      of 2:
-        try:
-          request.protocol = parseProtocol(linePart)
-        except ValueError:
-          asyncCheck request.respond(Http400,
-            "Invalid request protocol. Got: " & linePart)
-          continue
-      else:
-        await request.respond(Http400, "Invalid request. Got: " & lineFut.mget)
-        continue
-      inc i
+    if lineFut.mget == "":
+      # Can't read - connection is closed.
+      return false
 
-    # Headers
-    while true:
-      i = 0
-      lineFut.mget.setLen(0)
-      lineFut.clean()
-      await client.recvLineInto(lineFut)
-
-      if lineFut.mget == "":
-        client.close(); return
-      if lineFut.mget == "\c\L": break
-      let (key, value) = parseHeader(lineFut.mget)
-      request.headers[key] = value
-      # Ensure the client isn't trying to DoS us.
-      if request.headers.len > headerLimit:
-        await client.sendStatus("400 Bad Request")
-        request.client.close()
-        return
-
-    debug(requestLogMsg(request))
-
-    if request.reqMethod == "post":
-      # Check for Expect header
-      if request.headers.hasKey("Expect"):
-        if "100-continue" in request.headers["Expect"]:
-          await client.sendStatus("100 Continue")
-        else:
-          await client.sendStatus("417 Expectation Failed")
-
-    # Create body object (if needed)
-    # - Check for Content-length header
-    if request.headers.hasKey("Content-Length"):
-      var contentLength = 0
-      if parseInt(request.headers["Content-Length"],
-                  contentLength) == 0:
-        await request.respond(Http400, "Bad Request. Invalid Content-Length.")
-        continue
-      else:
-        request.reqBody = processBody(client, contentLength)
-    elif request.reqMethod == "post":
-      await request.respond(Http400, "Bad Request. No Content-Length.")
-      continue
-
-    case request.reqMethod
-    of "get", "post", "head", "put", "delete", "trace", "options",
-       "connect", "patch":
-      await callback(request)
-    else:
-      await request.respond(Http400, "Invalid request method. Got: " &
-        request.reqMethod)
-
-    if "upgrade" in request.headers.getOrDefault("connection"):
-      return
-
-    # Make sure the body is fully read
-    if not request.reqBody.isNil and request.reqBody.data.isNil:
-      discard await(request.reqBody.getStream.readAll)
-
-    # Persistent connections
-    if (request.protocol == HttpVer11 and
-        request.headers.getOrDefault("connection").normalize != "close") or
-       (request.protocol == HttpVer10 and
-        request.headers.getOrDefault("connection").normalize == "keep-alive"):
-      # In HTTP 1.1 we assume that connection is persistent. Unless connection
-      # header states otherwise.
-      # In HTTP 1.0 we assume that the connection should not be persistent.
-      # Unless the connection header states otherwise.
-      discard
-    else:
-      request.client.close()
+    if lineFut.mget != "\c\L":
       break
+
+  # First line - GET /path HTTP/1.1
+  var i = 0
+  for linePart in lineFut.mget.split(' '):
+    case i
+    of 0: request.reqMethod.shallowCopy(linePart.normalize)
+    of 1: parseUri(linePart, request.url)
+    of 2:
+      var failed = false
+      try:
+        request.protocol = parseProtocol(linePart)
+      except ValueError:
+        failed = true
+
+      if failed: await fail("Invalid request protocol. Got: " & linePart)
+    else:
+      await fail("Invalid request. Got: " & lineFut.mget)
+    inc i
+
+  # Headers
+  while true:
+    i = 0
+    lineFut.mget.setLen(0)
+    lineFut.clean()
+    await client.recvLineInto(lineFut)
+
+    if lineFut.mget == "":
+      client.close(); return false
+    if lineFut.mget == "\c\L": break
+    let (key, value) = parseHeader(lineFut.mget)
+    request.headers[key] = value
+    # Ensure the client isn't trying to DoS us.
+    if request.headers.len > headerLimit:
+      await fail("Too many headers in request")
+
+  debug(requestLogMsg(request))
+
+  if request.reqMethod == "post":
+    # Check for Expect header
+    if request.headers.hasKey("Expect"):
+      if "100-continue" in request.headers["Expect"]:
+        await client.sendStatus("100 Continue")
+      else:
+        await client.sendStatus("417 Expectation Failed")
+
+  # Create body object (if needed)
+  # - Parse relevant headers
+  var contentLength = none(int64)
+  if request.headers.hasKey("Content-Length"):
+    var data: int64 = 0
+    # TODO: multiple `Content-Length` fields
+    if parseBiggestInt(request.headers["Content-Length"], data) == 0:
+      # Can't determine the length - unrecoverable (RFC 7230 3.3.3)
+      await fail("Invalid Content-Length")
+    contentLength = data.some
+
+  var transferEncoding = teDefault
+  if request.headers.hasKey("Transfer-Encoding"):
+    let value: string = request.headers["Transfer-Encoding"]
+    # TODO: multiple encodings
+    if value == "chunked": transferEncoding = teChunked
+    else:
+      # Can't determine the length - unrecoverable (RFC 7230 3.3.3).
+      await fail("Unsupported Transfer-Encoding")
+
+  # - Check header combinations, create the body
+  #   see RFC7230 3.3.3
+  if transferEncoding == teChunked:
+    # Content-Length is overriden.
+    request.reqBody = newChunkedRequestBody(
+      newAsyncSocketStream(client)
+    )
+  elif contentLength.isSome:
+    request.reqBody = newSizedRequestBody(
+      newAsyncSocketStream(client),
+      contentLength.get
+    )
+  else:
+    # No length or encoding - expecting empty body
+    request.reqBody = newEmptyRequestBody()
+
+  case request.reqMethod
+  of "get", "post", "head", "put", "delete", "trace", "options",
+     "connect", "patch":
+    # `await` inside `try` is broken: https://github.com/nim-lang/Nim/issues/2528
+    await callback(request)
+
+  else:
+    await request.respond(Http400, "Invalid request method. Got: " &
+      request.reqMethod)
+    # No failure here - we just skip this message
+
+  # Make sure the body is fully read
+  if not request.reqBody.isNil and request.reqBody.kind != rbkCached:
+    # Malformed body exceptions here are not handled - we can't respond after the
+    # user-provided callback has started.
+
+    # TODO: `readAll` keeps the whole thing in memory. Replace it.
+    # `await` inside `try` is broken: https://github.com/nim-lang/Nim/issues/2528
+    discard(await(request.reqBody.getStream.readAll))
+
+  # Persistent connections
+  # In HTTP 1.1 we assume that connection is persistent. Unless connection
+  # header states otherwise.
+  # In HTTP 1.0 we assume that the connection should not be persistent.
+  # Unless the connection header states otherwise.
+  let keepAlive =
+    (request.protocol == HttpVer11 and
+     request.headers.getOrDefault("connection").normalize != "close") or
+    (request.protocol == HttpVer10 and
+     request.headers.getOrDefault("connection").normalize == "keep-alive")
+
+  return keepAlive
+
+proc processClient(
+  client: AsyncSocket, address: string,
+  callback: proc (request: Request): Future[void] {.closure, gcsafe.}
+) {.async.} =
+  ## Implements full HTTP connection lifecycle and logging.
+  while true:
+    let keepAliveFut = processOneRequest(client, address, callback)
+    yield keepAliveFut
+    try:
+      let keepAlive = keepAliveFut.read
+      if not keepAlive: break
+    except MalformedHttpException:
+      # These are less likely to signal a serious error, so we log them as `debug`
+      let e = getCurrentException()
+      debug(
+        "Failed to read request body: ",
+        e.name, ": ", e.msg, "\L",
+        e.getStackTrace
+      )
+      break
+    except:
+      let e = getCurrentException()
+      warn(
+        "Uncaught exception in HTTP handler for ", address, ": ",
+        e.name, ": ", e.msg, "\L",
+        e.getStackTrace
+      )
+      break
+
+  client.close
 
 proc serve*(server: AsyncHttpServer, port: Port,
             callback: proc (request: Request): Future[void] {.closure,gcsafe.},

--- a/src/boost/http/httpcommon.nim
+++ b/src/boost/http/httpcommon.nim
@@ -103,6 +103,9 @@ type
     charset*: string
     boundary*: string
 
+  MalformedHttpException* = object of Exception
+    ## Raised in case of malformed HTTP request
+
 proc parseContentType*(value: string): ContentType =
   ## Parses the ``value`` of `Content-Type` header
   let (mt, rest) = value.parseCHeader

--- a/src/boost/io/asyncstreams.nim
+++ b/src/boost/io/asyncstreams.nim
@@ -49,7 +49,7 @@ type
     ##   itself.
     ## * ``peekLineImpl`` is the optimized version for ``peekLine`` operation. If it's nil,
     ##   then module tries to emulate ``peekLine`` if it's possible via:
-    ##   * ``getPostion``, ``setPosition`` and ``readLine``
+    ##   * ``getPosition``, ``setPosition`` and ``readLine``
     ##   * ``peekBuffer`` with fixed size buffer.
     ## * if ``flushImpl`` is nil, ``flush`` operation does nothing.
     closeImpl*: proc (s: AsyncStream) {.nimcall, tags:[], gcsafe.}

--- a/tests/boost/http/test_asyncchunkedstream.nim
+++ b/tests/boost/http/test_asyncchunkedstream.nim
@@ -1,5 +1,6 @@
 import asyncdispatch, unittest, strutils, random, sequtils, future
 import boost.io.asyncstreams, boost.http.asyncchunkedstream
+import boost.http.httpcommon
 
 const allChars: seq[char] = toSeq('\0'..'\255')
 const allCharsExceptNewline = allChars.filter(t => t notIn {'\c', '\L'})
@@ -98,7 +99,7 @@ suite "AsyncChunkedStream":
     let input = newAsyncStringStream("this\c\Lis not valid")
     let wrapped = newAsyncChunkedStream(input)
 
-    expect(MalformedChunkedStreamError) do:
+    expect(MalformedHttpException) do:
       discard waitFor(wrapped.readData(10))
 
     check: wrapped.atEnd
@@ -161,5 +162,5 @@ suite "AsyncChunkedStream":
       let wrapped = newAsyncChunkedStream(input)
       defer: wrapped.close()
 
-      expect(MalformedChunkedStreamError) do:
+      expect(MalformedHttpException) do:
         discard waitFor(wrapped.readAll)

--- a/tests/boost/http/test_asyncchunkedstream.nim
+++ b/tests/boost/http/test_asyncchunkedstream.nim
@@ -1,0 +1,165 @@
+import asyncdispatch, unittest, strutils, random, sequtils, future
+import boost.io.asyncstreams, boost.http.asyncchunkedstream
+
+const allChars: seq[char] = toSeq('\0'..'\255')
+const allCharsExceptNewline = allChars.filter(t => t notIn {'\c', '\L'})
+
+type
+  # Restricts `readImpl` to read 1 to `maxBytesRead` bytes per call
+  ThrottleStream = ref ThrottleStreamObj
+  ThrottleStreamObj = object of AsyncStream
+    src: AsyncStream
+    maxBytesRead: Natural
+
+proc tRead(s: AsyncStream, buf: pointer, size0: int): Future[int] {.gcsafe.} =
+  let size = random(1..min(size0, s.ThrottleStream.maxBytesRead).succ)
+  s.ThrottleStream.src.readBuffer(buf, size)
+
+proc newThrottleStream(
+  input: AsyncStream,
+  maxBytesRead: Natural = 4
+): ThrottleStream =
+  new result
+  result.src = input
+  wrapAsyncStream(ThrottleStream, src)
+
+  result.maxBytesRead = maxBytesRead
+  result.readImpl = cast[type(result.readImpl)](tRead)
+
+proc randomBool(p: float = 0.5): bool = random(1.0) < p
+
+proc randomString(size: Natural, chars: openarray[char] = allChars): string =
+  result = newString(size)
+  for i in 0..<size:
+    result[i] = random(chars)
+
+proc genChunked(): tuple[data: string, encoded: string] =
+  let numChunks = random(3)
+  var data = ""
+  var encoded = ""
+  for chunkIdx in 0..<numChunks:
+    let size = random(1..100)
+    let chunk = randomString(size)
+    data.add(chunk)
+
+    var sizeStr = toHex(size)
+    trimZeros(sizeStr)
+    sizeStr = repeat('0', random(3)) & sizeStr
+
+    encoded.add(sizeStr)
+    if randomBool():
+      let extension = randomString(random(20), allCharsExceptNewline)
+      encoded.add(";")
+      encoded.add(extension)
+
+    encoded.add("\c\L")
+    encoded.add(chunk)
+    encoded.add("\c\L")
+
+  encoded.add(repeat('0', random(1..10)))
+  if randomBool():
+    let extension = randomString(random(20), allCharsExceptNewline)
+    encoded.add(";")
+    encoded.add(extension)
+
+  encoded.add("\c\L")
+
+  let trailerLines = random(1..3)
+  for i in 0..<trailerLines:
+    encoded.add(randomString(random(1..100), allCharsExceptNewline))
+    encoded.add("\c\L")
+
+  encoded.add("\c\L")
+
+  (data, encoded)
+
+suite "AsyncChunkedStream":
+  test "should work with a simple example":
+    let encoded = "4\c\LWiki\c\L5\c\Lpedia\c\LE\c\L in\c\L\c\Lchunks.\c\L0\c\L\c\L"
+    let input = newAsyncStringStream(encoded)
+    let wrapped = newAsyncChunkedStream(input)
+    defer: wrapped.close()
+    let decoded = waitFor(wrapped.readAll)
+    check: decoded == "Wikipedia in\c\L\c\Lchunks."
+
+  test "should close the underlying stream":
+    let input = newAsyncStringStream("0\c\L\c\Lremainder")
+    let wrapped = newAsyncChunkedStream(input)
+
+    check: waitFor(wrapped.readAll) == ""
+    check: wrapped.atEnd
+    check: not input.atEnd
+
+    wrapped.close()
+    check: wrapped.atEnd
+    check: input.atEnd
+
+  test "should close the underlying stream even after malformed data":
+    let input = newAsyncStringStream("this\c\Lis not valid")
+    let wrapped = newAsyncChunkedStream(input)
+
+    expect(MalformedChunkedStreamError) do:
+      discard waitFor(wrapped.readData(10))
+
+    check: wrapped.atEnd
+    check: not input.atEnd
+
+    wrapped.close()
+    check: wrapped.atEnd
+    check: input.atEnd
+
+  test "should work with randomized examples":
+    # TODO: it might be useful to check some specific conditions first
+    for iteration in 1..100:
+      let (data, encoded) = genChunked()
+      let expectedLeftover = randomString(10)
+      let inputString = encoded & expectedLeftover
+      let input = newAsyncStringStream(inputString)
+      let wrapped = newAsyncChunkedStream(input)
+      defer: wrapped.close()
+
+      try:
+        let decoded = waitFor(wrapped.readAll)
+        check: decoded == data
+      except:
+        echo "data (", data.len, " bytes): \L", escape(data)
+        echo "input string (", inputString.len, " bytes): \L", escape(inputString)
+        echo "position: ", input.getPosition
+        raise
+
+      let leftover = waitFor(input.readAll)
+      check: leftover == expectedLeftover
+
+  test "should work with partial reads":
+    # Stream parsers can be brittle in case of partial reads.
+    for iteration in 1..100:
+      let (data, encoded) = genChunked()
+      let expectedLeftover = randomString(10)
+      let inputString = encoded & expectedLeftover
+      let input = newThrottleStream(newAsyncStringStream(inputString))
+      let wrapped = newAsyncChunkedStream(input)
+      defer: wrapped.close()
+
+      try:
+        let decoded = waitFor(wrapped.readAll)
+        check: decoded == data
+      except:
+        echo "data (", data.len, " bytes): \L", escape(data)
+        echo "input string (", inputString.len, " bytes): \L", escape(inputString)
+        echo "position: ", input.getPosition
+        raise
+
+      let leftover = waitFor(input.readAll)
+      check: leftover == expectedLeftover
+
+  test "should fail for truncated randomized examples":
+    for iteration in 1..100:
+      let (data, encoded) = genChunked()
+      # make sure at least one byte is truncated
+      let inputString = encoded[0..<random(0..<encoded.len)]
+      let input = newAsyncStringStream(inputString)
+      let wrapped = newAsyncChunkedStream(input)
+      defer: wrapped.close()
+
+      expect(MalformedChunkedStreamError) do:
+        discard waitFor(wrapped.readAll)

--- a/tests/boost/test_all.nim
+++ b/tests/boost/test_all.nim
@@ -25,12 +25,18 @@ else:
          data.test_rbtree,
          data.test_props,
          data.test_memory
-  # I/O
-  import io.test_asyncstreams
-  # HTTP
+
+  # HTTP - pure parts
+  # asyncstreams test slows down execution for some reason (dispatcher?). So we
+  # run "heavy" tests before that.
   import http.test_httpcommon,
          http.test_multipart,
-         http.test_asynchttpserver,
          http.test_asyncchunkedstream
+
+  # I/O
+  import io.test_asyncstreams
+
+  # HTTP server
+  import http.test_asynchttpserver
          # Disabled because of https://github.com/nim-lang/Nim/issues/5417
          # http.test_jester

--- a/tests/boost/test_all.nim
+++ b/tests/boost/test_all.nim
@@ -30,6 +30,7 @@ else:
   # HTTP
   import http.test_httpcommon,
          http.test_multipart,
-         http.test_asynchttpserver
+         http.test_asynchttpserver,
+         http.test_asyncchunkedstream
          # Disabled because of https://github.com/nim-lang/Nim/issues/5417
          # http.test_jester


### PR DESCRIPTION
Improvements to `asynchttpserver` module:
1. Log requests, responses and error conditions on `asynchttpserver` level. Jester tries to do this, but it can't capture malformed HTTP problems, which is when we need this information the most.
2. Support chunked requests.
3. Close the connection in case of parsing errors whenever we can't safely skip the request. Reopening the connection is cheaper than dealing with the aftermath of botched HTTP connection in an unrelated request.
4. Factor out handling a request to a separate proc, replacing `client.close`/`continue`/`break`/`return` spaghetti with return value and exceptions.
5. Untangle `RequestBodyStream` from `RequestBody`, change `RequestBody` structure to express valid states wrt caching.

Possible problems:
1. `len(RequestBody)` now throws `ValueError` for chunked body (if it was not previously cached).
2. Reading from the body stream can now throw a `MalformedHttpException`. Using return values would have been too easy to mess up.
3. Changed the test order. It seems that `asyncstreams` test slows down following tests that use futures. `asynchunckedstream` is particularly heavy in this regard, leading to an extremely long duration. This should probably get looked at, but it is not a focus of this PR.