### PR TITLE
Nim 0.19

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -4,10 +4,10 @@ import ospaths, strutils, sequtils
 
 type Target {.pure.} = enum JS, C
 
-template dep(task: untyped): stmt =
+template dep(task: untyped): untyped =
   selfExec astToStr(task)
 
-template deps(a, b: untyped): stmt =
+template deps(a, b: untyped): untyped =
   dep(a)
   dep(b)
 

--- a/nimboost.nimble
+++ b/nimboost.nimble
@@ -7,4 +7,4 @@ license       = "MIT"
 srcDir = "src"
 
 # [Deps]
-requires "nim >= 0.18.0", "patty >= 0.3.1"
+requires "nim >= 0.19.0", "patty >= 0.3.3"

--- a/src/boost/data/props.nim
+++ b/src/boost/data/props.nim
@@ -77,10 +77,6 @@ proc clear*(p: var Props) =
   ## Clears mutable properties set ``p``
   ((seq[Prop])p).setLen(0)
 
-proc isNil*(p: Props): bool =
-  ## Checks 
-  ((seq[Prop])p).isNil
-
 proc toStringTable*(p: Props, t: StringTableRef) =
   for k, v in p.pairs:
     t[k] = v

--- a/src/boost/http/asyncchunkedstream.nim
+++ b/src/boost/http/asyncchunkedstream.nim
@@ -52,11 +52,11 @@ proc readExactly(s: AsyncChunkedStream, size: Natural): Future[string] {.async.}
 proc readExpected(
   s: AsyncChunkedStream,
   expected: string,
-  description: string = nil
+  description: string = ""
 ): Future[void] {.async.} =
   let got = await s.readExactly(expected.len)
   if expected != got:
-    let effectiveDesc = if description.isNil: escape(expected) else: description
+    let effectiveDesc = if description.len == 0: escape(expected) else: description
     raiseError(s, effectiveDesc & " expected, got " & escape(got))
 
 proc readHttpLine(s: AsyncChunkedStream): Future[string] {.async.} =

--- a/src/boost/http/asynchttpserver.nim
+++ b/src/boost/http/asynchttpserver.nim
@@ -300,7 +300,7 @@ proc processOneRequest(
 
     await client.recvLineInto(lineFut) # TODO: Timeouts.
 
-    if lineFut.mget == "":
+    if lineFut.mget.len == 0:
       # Can't read - connection is closed.
       return false
 
@@ -332,7 +332,7 @@ proc processOneRequest(
     lineFut.clean()
     await client.recvLineInto(lineFut)
 
-    if lineFut.mget == "": return false
+    if lineFut.mget.len == 0: return false
     if lineFut.mget == "\c\L": break
     let (key, value) = parseHeader(lineFut.mget)
     request.headers[key] = value

--- a/src/boost/http/httpcommon.nim
+++ b/src/boost/http/httpcommon.nim
@@ -35,14 +35,14 @@ proc formEncode*(form: Props): string =
   ## Encodes ``form`` to `application/x-www-form-urlencoded` format
   for k, v in form.pairs:
     let s = urlEncode(k) & "=" & urlEncode(v)
-    if result.isNil:
+    if result.len == 0:
       result = s
     else:
       result &= "&" & s
 
 proc formDecode*(data: string, form: var Props) =
   ## Decodes ``data`` from `application/x-www-form-urlencoded` format into ``form``
-  if form.isNil:
+  if form.len == 0:
     form = newProps()
   else:
     form.clear
@@ -69,7 +69,7 @@ proc readHeaders*(s: AsyncStream): Future[Props] {.async.} =
   var prevLine = ""
   while true:
     let line = await s.readLine
-    if line == "":
+    if line.len == 0:
       break
     if line[0] == ' ' or line[0] == '\t':
       prevLine.add(line[line.skipWhitespace..^1])

--- a/src/boost/http/impl/utils.nim
+++ b/src/boost/http/impl/utils.nim
@@ -24,7 +24,7 @@ proc parseUrlQuery*(query: string, result: var StringTableRef) =
 
 ]#
 
-template parseContentDisposition(): stmt =
+template parseContentDisposition(): untyped =
   var hCount = 0
   while hCount < hValue.len()-1:
     var key = ""

--- a/src/boost/http/jester.nim
+++ b/src/boost/http/jester.nim
@@ -255,7 +255,7 @@ proc parseReqMethod(reqMethod: string, output: var ReqMeth): bool =
   else:
     result = false
 
-template setMatches(req: expr) = req.matches = matches # Workaround.
+template setMatches(req: untyped) = req.matches = matches # Workaround.
 proc handleRequest(jes: Jester, client: AsyncSocket,
                    path, query: string, body: RequestBody, ip, reqMethod: string,
                    headers: HttpHeaders) {.async.} =
@@ -380,14 +380,14 @@ proc serve*(
 
 template resp*(code: HttpCode,
                headers: openarray[tuple[key, value: string]],
-               content: string): stmt =
+               content: string): typed =
   ## Sets ``(code, headers, content)`` as the response.
   bind TCActionSend, newStringTable
   response.data = (TCActionSend, code, headers.newStringTable, content)
   # The ``route`` macro will add a 'return' after the invokation of this
   # template.
 
-template resp*(content: string, contentType = "text/html;charset=utf-8"): stmt =
+template resp*(content: string, contentType = "text/html;charset=utf-8"): typed =
   ## Sets ``content`` as the response; ``Http200`` as the status code
   ## and ``contentType`` as the Content-Type.
   bind TCActionSend, newStringTable, strtabs.`[]=`
@@ -399,7 +399,7 @@ template resp*(content: string, contentType = "text/html;charset=utf-8"): stmt =
   # template.
 
 template resp*(code: HttpCode, content: string,
-               contentType = "text/html;charset=utf-8"): stmt =
+               contentType = "text/html;charset=utf-8"): typed =
   ## Sets ``content`` as the response; ``code`` as the status code
   ## and ``contentType`` as the Content-Type.
   bind TCActionSend, newStringTable
@@ -410,7 +410,7 @@ template resp*(code: HttpCode, content: string,
   # The ``route`` macro will add a 'return' after the invokation of this
   # template.
 
-template body*(): expr =
+template body*(): untyped =
   ## Gets the body of the request.
   ##
   ## **Note:** It's usually a better idea to use the ``resp`` templates.
@@ -419,19 +419,19 @@ template body*(): expr =
   # This means that it is up to guessAction to infer this if the user adds
   # something to the body for example.
 
-template headers*(): expr =
+template headers*(): untyped =
   ## Gets the headers of the request.
   ##
   ## **Note:** It's usually a better idea to use the ``resp`` templates.
   response.data[2]
 
-template status*(): expr =
+template status*(): untyped =
   ## Gets the status of the request.
   ##
   ## **Note:** It's usually a better idea to use the ``resp`` templates.
   response.data[1]
 
-template redirect*(url: string): stmt =
+template redirect*(url: string): typed =
   ## Redirects to ``url``. Returns from this request handler immediately.
   ## Any set response headers are preserved for this request.
   bind TCActionSend, newStringTable
@@ -442,7 +442,7 @@ template redirect*(url: string): stmt =
   # The ``route`` macro will add a 'return' after the invokation of this
   # template.
 
-template pass*(): stmt =
+template pass*(): typed =
   ## Skips this request handler.
   ##
   ## If you want to stop this request from going further use ``halt``.
@@ -450,7 +450,7 @@ template pass*(): stmt =
   # The ``route`` macro will perform a transformation which ensures a
   # call to this template behaves correctly.
 
-template cond*(condition: bool): stmt =
+template cond*(condition: bool): typed =
   ## If ``condition`` is ``False`` then ``pass`` will be called,
   ## i.e. this request handler will be skipped.
   # The ``route`` macro will perform a transformation which ensures a
@@ -458,7 +458,7 @@ template cond*(condition: bool): stmt =
 
 template halt*(code: HttpCode,
                headers: varargs[tuple[key, val: string]],
-               content: string): stmt =
+               content: string): typed =
   ## Immediately replies with the specified request. This means any further
   ## code will not be executed after calling this template in the current
   ## route.
@@ -467,21 +467,21 @@ template halt*(code: HttpCode,
   # The ``route`` macro will add a 'return' after the invokation of this
   # template.
 
-template halt*(): stmt =
+template halt*(): typed =
   ## Halts the execution of this request immediately. Returns a 404.
   ## All previously set values are **discarded**.
   halt(Http404, {"Content-Type": "text/html;charset=utf-8"}, error($Http404, jesterVer))
 
-template halt*(code: HttpCode): stmt =
+template halt*(code: HttpCode): typed =
   halt(code, {"Content-Type": "text/html;charset=utf-8"}, error($code, jesterVer))
 
-template halt*(content: string): stmt =
+template halt*(content: string): typed =
   halt(Http404, {"Content-Type": "text/html;charset=utf-8"}, content)
 
-template halt*(code: HttpCode, content: string): stmt =
+template halt*(code: HttpCode, content: string): typed =
   halt(code, {"Content-Type": "text/html;charset=utf-8"}, content)
 
-template attachment*(filename = ""): stmt =
+template attachment*(filename = ""): typed =
   ## Creates an attachment out of ``filename``. Once the route exits,
   ## ``filename`` will be sent to the person making the request and web browsers
   ## will be hinted to open their Save As dialog box.
@@ -493,7 +493,7 @@ template attachment*(filename = ""): stmt =
     if not response.data[2].hasKey("Content-Type") and ext != "":
       response.data[2]["Content-Type"] = getMimetype(request.settings.mimes, ext)
 
-template `@`*(s: string): expr =
+template `@`*(s: string): untyped =
   ## Retrieves the parameter ``s`` from ``request.params``. ``""`` will be
   ## returned if parameter doesn't exist.
   if request.params.hasKey(s):
@@ -545,7 +545,7 @@ proc makeUri*(request: jester.Request, address = "", absolute = true,
     uri = uri / request.pathInfo
   return $uri
 
-template uri*(address = "", absolute = true, addScriptName = true): expr =
+template uri*(address = "", absolute = true, addScriptName = true): untyped =
   ## Convenience template which can be used in a route.
   request.makeUri(address, absolute, addScriptName)
 
@@ -553,7 +553,7 @@ proc daysForward*(days: int): TimeInfo =
   ## Returns a TimeInfo object referring to the current time plus ``days``.
   (getTime() + initInterval(days = days)).utc
 
-template setCookie*(name, value: string, expires: TimeInfo): stmt =
+template setCookie*(name, value: string, expires: TimeInfo): typed =
   ## Creates a cookie which stores ``value`` under ``name``.
   bind setCookie
   if response.data[2].hasKey("Set-Cookie"):
@@ -632,7 +632,7 @@ proc ctParsePattern(pattern: string): NimNode {.compiletime.} =
       newStrLitNode(node.text),
       newIdentNode(if node.optional: "true" else: "false"))
 
-template setDefaultResp(): stmt =
+template setDefaultResp(): typed =
   # TODO: bindSym this in the 'routes' macro and put it in each route
   bind TCActionNothing, newStringTable
   response.data.action = TCActionNothing
@@ -640,7 +640,7 @@ template setDefaultResp(): stmt =
   response.data.headers = {:}.newStringTable
   response.data.content = ""
 
-template declareSettings(): stmt {.immediate, dirty.} =
+template declareSettings(): typed {.dirty.} =
   when not declaredInScope(settings):
     var settings = newSettings()
 
@@ -758,7 +758,7 @@ template enumValue(
     newIdentNode(valueName)
   )
 
-macro routesFuture*(body: stmt): untyped{.immediate.} =
+macro routesFuture*(body: untyped): Future[void] =
   ## This version of `routes` returns a `Future` that runs until the server
   ## encounters an error from which it cannot recover (for example,
   ## when attempting to bind on a port that is already taken),
@@ -869,11 +869,11 @@ macro routesFuture*(body: stmt): untyped{.immediate.} =
   #echo toStrLit(result)
   #echo treeRepr(result)
 
-template routes*(body: stmt): untyped {.immediate.} =
+template routes*(body: untyped): typed =
   bind asyncCheck, routesFuture
   asyncCheck routesFuture(body)
 
-macro settings*(body: stmt): stmt {.immediate.} =
+macro settings*(body: untyped): typed =
   #echo(treeRepr(body))
   expectKind(body, nnkStmtList)
 

--- a/src/boost/io/asyncstreams.nim
+++ b/src/boost/io/asyncstreams.nim
@@ -30,7 +30,7 @@ import asyncdispatch, asyncnet, asyncfile, macros
 ##    var res = newSeq[string]()
 ##    while true:
 ##      let l = await s.readLine()
-##      if l == "":
+##      if l.len == 0:
 ##        break
 ##      res.add(l)
 ##    doAssert(res.join(", ") == "Hello, world!")

--- a/src/boost/jsonserialize.nim
+++ b/src/boost/jsonserialize.nim
@@ -1,4 +1,4 @@
-import json, strutils, algorithm, boost.parsers
+import json, strutils, algorithm, boost/parsers
 
 type
   FieldException* = object of Exception
@@ -28,7 +28,7 @@ proc fromJson*(_: typedesc[int], n: JsonNode): int =
   if n == nil:
     raise newFieldException("Can't get field of type int")
   else:
-    return n.getNum.int
+    return n.getInt
 
 proc toJson*(v: int): JsonNode =
   newJInt(v)

--- a/src/boost/limits.nim
+++ b/src/boost/limits.nim
@@ -1,38 +1,18 @@
 ## This module introduces limits for some data types
 
-template ordLimitDecl(typ: typedesc): untyped =
-  proc min*(t = typ): typ = low(typ)
-  proc max*(t = typ): typ = high(typ)
-template intLimitDecl(typ: typedesc, minValue, maxValue: typed): untyped =
-  proc min*(t = typ): typ = minValue
-  proc max*(t = typ): typ = maxValue
-template intLimitDeclMD(typ: typedesc, minValue4, maxValue4, minValue8, maxValue8: typed): untyped =
-  proc min*(t = typ): typ =
-    when sizeof(typ) == 4:
-      (typ)minValue4
-    elif sizeof(typ) == 8:
-      (typ)minValue8
-    else:
-      {.fatal: "Limits: can't get minimal value for type " & astToStr(typ) & " when sizeof == " & $sizeof(typ).}
-  proc max*(t = typ): typ =
-    when sizeof(typ) == 4:
-      (typ)maxValue4
-    elif sizeof(typ) == 8:
-      (typ)maxValue8
-    else:
-      {.fatal: "Limits: can't get maximal value for type " & astToStr(typ) & " when sizeof == " & $sizeof(typ).}
+proc min*[T: Ordinal](t: typedesc[T]): T = T.low
+proc max*[T: Ordinal](t: typedesc[T]): T = T.high
 
-# Signed integer types
-int8.ordLimitDecl
-int16.ordLimitDecl
-int32.ordLimitDecl
-int64.ordLimitDecl
-int.ordLimitDecl
-  
-# Unsigned integer types
-uint8.ordLimitDecl
-uint16.ordLimitDecl
-uint32.ordLimitDecl
-# uint and uint64 is not ordinal types, see ``Pre-defined integer types`` in the manual
-uint64.intLimitDecl(0'u64, 0xFFFF_FFFF_FFFF_FFFF'u64)
-uint.intLimitDeclMD(0'u32, 0xFFFF_FFFF'u32, 0'u64, 0xFFFF_FFFF_FFFF_FFFF'u64)
+# uint and uint64 are not `Ordinal` types, see ``Pre-defined integer types``
+# in the manual.
+proc min*(t: typedesc[uint64]): uint64 = 0'u64
+proc max*(t: typedesc[uint64]): uint64 = 0xFFFF_FFFF_FFFF_FFFF'u64
+
+proc min*(t: typedesc[uint]): uint = 0'u
+
+when (sizeof(uint) == 8):
+  proc max*(t: typedesc[uint]): uint = 0xFFFF_FFFF_FFFF_FFFF'u
+elif (sizeof(uint) == 4):
+  proc max*(t: typedesc[uint]): uint = 0xFFFF_FFFF'u
+else:
+    {.fatal: "Limits: can't get minimal value for type uint when sizeof == " & $sizeof(uint).}

--- a/src/boost/richstring.nim
+++ b/src/boost/richstring.nim
@@ -3,7 +3,7 @@
 import parseutils, sequtils, macros, options, strutils, ./formatters, ./parsers
 
 proc parseIntFmt(fmtp: string): tuple[maxLen: int, fillChar: char] =
-  var maxLen = if fmtp == "": 0 else: strToInt(fmtp)
+  var maxLen = if fmtp.len == 0: 0 else: strToInt(fmtp)
   var minus = fmtp.len > 0 and fmtp[0] == '-'
   var fillChar = if ((minus and fmtp.len > 1) or fmtp.len > 0) and fmtp[if minus: 1 else: 0] == '0': '0' else: ' '
   (maxLen, fillChar)
@@ -11,7 +11,7 @@ proc parseIntFmt(fmtp: string): tuple[maxLen: int, fillChar: char] =
 proc parseFloatFmt(fmtp: string): tuple[maxLen: int, prec: Option[int], fillChar: char] =
   result.fillChar = ' '
 
-  if fmtp == "":
+  if fmtp.len == 0:
     return
   var t = ""
   var minus = 1
@@ -76,7 +76,7 @@ proc handleFormat(exp: string, fmt: string, nodes: var seq[NimNode]) {.compileTi
           fmtp = fmt[1..idx-1]
         break
       inc idx
-    if fmtm == "":
+    if fmtm.len == 0:
       nodes.add(parseExpr("$(" & exp & ")"))
       nodes.add(newLit(fmt))
     else:

--- a/src/boost/richstring.nim
+++ b/src/boost/richstring.nim
@@ -108,7 +108,7 @@ macro fmt*(fmt: static[string]): untyped =
   ##
   ## .. code-block:: Nim
   ##
-  ##   import boost.richstring
+  ##   import boost/richstring
   ##
   ##   let s = "string"
   ##   assert fmt"${s[0..2].toUpperAscii}" == "STR"

--- a/src/boost/typeutils.nim
+++ b/src/boost/typeutils.nim
@@ -58,7 +58,7 @@
 ##
 ##  *More documentation is coming, for now please see the tests in tests/boost/test_typeutils.nim*
 
-import macros, options, future, strutils
+import macros, options, sugar, strutils
 
 type
   GenericParam = string
@@ -324,7 +324,7 @@ when false:
         obj = obj.getType
       of nnkBracketExpr:
         underlyingAlias = obj
-        obj = obj[0].symbol.getImpl
+        obj = obj[0].getImpl
       else:
         error("Unexpected underlying type kind " & $t.typeKind)
       if maxIter == 0:
@@ -344,7 +344,7 @@ proc genConstructorImpl(`type`: NimNode, n: Option[string], exported: bool): Nim
   expectLen `type`.getTypeInst, 2
   var t = `type`.getTypeInst[1]
   expectKind t, nnkSym
-  t = t.symbol.getImpl
+  t = t.getImpl
   expectLen t, 3
   var obj: NimNode
   var isRef: bool
@@ -380,7 +380,7 @@ proc genConstructorImpl(`type`: NimNode, n: Option[string], exported: bool): Nim
       obj = obj.getType
     of nnkBracketExpr:
       underlyingAlias = obj
-      obj = obj[0].symbol.getImpl
+      obj = obj[0].getImpl
     else:
       error("Unexpected underlying type kind " & $t.typeKind)
   if maxIter == 0:
@@ -413,7 +413,7 @@ proc genConstructorImpl(`type`: NimNode, n: Option[string], exported: bool): Nim
       newIdentDefs(ident($field), parseExpr(repr(field.getTypeInst)))
     if underlyingAlias.kind != nnkEmpty and underlyingGenParams.kind != nnkEmpty:
       for i in 0..<underlyingGenParams.len:
-        if idef[1].kind == nnkIdent and $(underlyingGenParams[i].symbol) == $(idef[1]):
+        if idef[1].kind == nnkIdent and $(underlyingGenParams[i]) == $(idef[1]):
           idef[1] = parseExpr($(underlyingAlias[i+1]))
 
     params.add(idef)

--- a/src/boost/typeutils.nim
+++ b/src/boost/typeutils.nim
@@ -202,7 +202,7 @@ proc newType(
 
 # Workaround for VM bug
 proc isNil(t: Type): bool =
-  t == nil or t.header.name.isNil
+  t == nil or t.header.name.len == 0
 
 proc `$`(t: Type): string =
   if t.isNil:

--- a/tests/boost/data/shuffle.nim
+++ b/tests/boost/data/shuffle.nim
@@ -1,5 +1,0 @@
-proc shuffle[T](xs: var openarray[T]) =
-  for i in countup(1, xs.len - 1):
-    let j = random(succ i)
-    swap(xs[i], xs[j])
-    

--- a/tests/boost/data/test_memory.nim
+++ b/tests/boost/data/test_memory.nim
@@ -1,4 +1,4 @@
-import boost.data.memory,
+import boost/data/memory,
        unittest
 
 suite "Memory":

--- a/tests/boost/data/test_props.nim
+++ b/tests/boost/data/test_props.nim
@@ -1,4 +1,4 @@
-import boost.data.props, unittest
+import boost/data/props, unittest
 
 suite "Props":
   test "Props":

--- a/tests/boost/data/test_rbtree.nim
+++ b/tests/boost/data/test_rbtree.nim
@@ -1,4 +1,4 @@
-import unittest, boost.data.rbtree, sets, random, sequtils, algorithm, random
+import unittest, boost/data/rbtree, sets, random, sequtils, algorithm, random
 
 suite "RBTree":
   test "Initialization":
@@ -61,8 +61,6 @@ suite "RBTree":
     check: s.len == 4
     s = s.del(1)
     check: s.len == 3
-
-  include shuffle
 
   test "Stress":
     randomize(1234)

--- a/tests/boost/data/test_rbtreem.nim
+++ b/tests/boost/data/test_rbtreem.nim
@@ -1,4 +1,4 @@
-import unittest, boost.data.rbtreem, sets, random, sequtils, algorithm, random
+import unittest, boost/data/rbtreem, sets, random, sequtils, algorithm, random
 
 suite "RBTreeM":
 
@@ -61,8 +61,6 @@ suite "RBTreeM":
     check: t1.del(2).len == 1
     t1.del(4)
     check: t1.del(4).len == 0
-
-  include shuffle
 
   test "Stress":
     randomize(1234)

--- a/tests/boost/data/test_stackm.nim
+++ b/tests/boost/data/test_stackm.nim
@@ -1,4 +1,4 @@
-import boost.data.stackm,
+import boost/data/stackm,
        unittest
 
 suite "StackM":

--- a/tests/boost/http/impl/run_test_server.nim
+++ b/tests/boost/http/impl/run_test_server.nim
@@ -1,6 +1,6 @@
-from boost.http.asynchttpserver import RequestBody, getStream
-from boost.io.asyncstreams import readAll
-import boost.http.multipart
+from boost/http/asynchttpserver import RequestBody, getStream
+from boost/io/asyncstreams import readAll
+import boost/http/multipart
 
 proc runSocketServer =
   proc run {.gcsafe.} =
@@ -36,7 +36,7 @@ proc runSocketServer =
         redirect(uri(@"url"))
 
       get "/win":
-        cond random(5) < 3
+        cond rand(4) < 3
         resp "<b>You won!</b>"
 
       get "/win":

--- a/tests/boost/http/test_asyncchunkedstream.nim
+++ b/tests/boost/http/test_asyncchunkedstream.nim
@@ -87,7 +87,7 @@ suite "AsyncChunkedStream":
     let input = newAsyncStringStream("0\c\L\c\Lremainder")
     let wrapped = newAsyncChunkedStream(input)
 
-    check: waitFor(wrapped.readAll) == ""
+    check: waitFor(wrapped.readAll).len == 0
     check: wrapped.atEnd
     check: not input.atEnd
 

--- a/tests/boost/http/test_asyncchunkedstream.nim
+++ b/tests/boost/http/test_asyncchunkedstream.nim
@@ -1,6 +1,6 @@
-import asyncdispatch, unittest, strutils, random, sequtils, future
-import boost.io.asyncstreams, boost.http.asyncchunkedstream
-import boost.http.httpcommon
+import asyncdispatch, unittest, strutils, random, sequtils, sugar
+import boost/io/asyncstreams, boost/http/asyncchunkedstream
+import boost/http/httpcommon
 
 const allChars: seq[char] = toSeq('\0'..'\255')
 const allCharsExceptNewline = allChars.filter(t => t notIn {'\c', '\L'})
@@ -13,7 +13,7 @@ type
     maxBytesRead: Natural
 
 proc tRead(s: AsyncStream, buf: pointer, size0: int): Future[int] {.gcsafe.} =
-  let size = random(1..min(size0, s.ThrottleStream.maxBytesRead).succ)
+  let size = rand(1..min(size0, s.ThrottleStream.maxBytesRead))
   s.ThrottleStream.src.readBuffer(buf, size)
 
 proc newThrottleStream(
@@ -27,29 +27,31 @@ proc newThrottleStream(
   result.maxBytesRead = maxBytesRead
   result.readImpl = cast[type(result.readImpl)](tRead)
 
-proc randomBool(p: float = 0.5): bool = random(1.0) < p
+proc randomBool(p: float = 0.5): bool = rand(1.0) < p
 
 proc randomString(size: Natural, chars: openarray[char] = allChars): string =
   result = newString(size)
   for i in 0..<size:
-    result[i] = random(chars)
+    result[i] = rand(chars)
 
 proc genChunked(): tuple[data: string, encoded: string] =
-  let numChunks = random(3)
+  let numChunks = rand(2)
   var data = ""
   var encoded = ""
   for chunkIdx in 0..<numChunks:
-    let size = random(1..100)
+    let size = rand(1..99)
     let chunk = randomString(size)
     data.add(chunk)
 
     var sizeStr = toHex(size)
+    # trim leading zeros
+    sizeStr = sizeStr[sizeStr.find({'1'..'F'})..sizeStr.len-1]
     trimZeros(sizeStr)
-    sizeStr = repeat('0', random(3)) & sizeStr
+    sizeStr = repeat('0', rand(2)) & sizeStr
 
     encoded.add(sizeStr)
     if randomBool():
-      let extension = randomString(random(20), allCharsExceptNewline)
+      let extension = randomString(rand(19), allCharsExceptNewline)
       encoded.add(";")
       encoded.add(extension)
 
@@ -57,17 +59,17 @@ proc genChunked(): tuple[data: string, encoded: string] =
     encoded.add(chunk)
     encoded.add("\c\L")
 
-  encoded.add(repeat('0', random(1..10)))
+  encoded.add(repeat('0', rand(1..9)))
   if randomBool():
-    let extension = randomString(random(20), allCharsExceptNewline)
+    let extension = randomString(rand(19), allCharsExceptNewline)
     encoded.add(";")
     encoded.add(extension)
 
   encoded.add("\c\L")
 
-  let trailerLines = random(1..3)
+  let trailerLines = rand(2)
   for i in 0..<trailerLines:
-    encoded.add(randomString(random(1..100), allCharsExceptNewline))
+    encoded.add(randomString(rand(1..99), allCharsExceptNewline))
     encoded.add("\c\L")
 
   encoded.add("\c\L")
@@ -148,6 +150,7 @@ suite "AsyncChunkedStream":
         echo "data (", data.len, " bytes): \L", escape(data)
         echo "input string (", inputString.len, " bytes): \L", escape(inputString)
         echo "position: ", input.getPosition
+        echo "input at position: ", escape(inputString[input.getPosition..inputString.len-1])
         raise
 
       let leftover = waitFor(input.readAll)
@@ -157,7 +160,7 @@ suite "AsyncChunkedStream":
     for iteration in 1..100:
       let (data, encoded) = genChunked()
       # make sure at least one byte is truncated
-      let inputString = encoded[0..<random(0..<encoded.len)]
+      let inputString = encoded[0..rand(-1..encoded.len - 2)]
       let input = newAsyncStringStream(inputString)
       let wrapped = newAsyncChunkedStream(input)
       defer: wrapped.close()

--- a/tests/boost/http/test_asynchttpserver.nim
+++ b/tests/boost/http/test_asynchttpserver.nim
@@ -78,6 +78,8 @@ suite "asynchttpserver":
   let url = "http://" & HOST & ":" & $PORT.int
 
   spawn serverThread()
+  #TODO: Wait for server to start
+  sleep(1000)
   defer: discard newHttpClient().postContent(url & "/quit", "")
 
   test "GET":

--- a/tests/boost/http/test_asynchttpserver.nim
+++ b/tests/boost/http/test_asynchttpserver.nim
@@ -1,4 +1,4 @@
-import boost.http.asynchttpserver
+import boost/http/asynchttpserver
 import unittest,
        asyncdispatch,
        threadpool,
@@ -6,7 +6,7 @@ import unittest,
        net,
        os,
        strutils,
-       boost.io.asyncstreams
+       boost/io/asyncstreams
 
 const PORT = 9998.Port
 const HOST = "localhost"

--- a/tests/boost/http/test_asynchttpserver_internals.nim
+++ b/tests/boost/http/test_asynchttpserver_internals.nim
@@ -36,5 +36,5 @@ suite "RequestBodyStream":
         let expectedS1 = bodyStr[0..<min(bodyStr.len, i)]
         check: s1 == expectedS1
         check: (s1 & s2) == bodyStr
-        check: s3 == ""
+        check: s3.len == 0
         check: underlying.getPosition == bodyStr.len

--- a/tests/boost/http/test_asynchttpserver_internals.nim
+++ b/tests/boost/http/test_asynchttpserver_internals.nim
@@ -1,12 +1,12 @@
 ## This is in a separate file since we need access to private functions, so
 ## we have to include rather than import.
 
-include boost.http.asynchttpserver
+include boost/http/asynchttpserver
 
 import unittest,
        asyncdispatch,
        strutils,
-       boost.io.asyncstreams
+       boost/io/asyncstreams
 
 suite "RequestBodyStream":
   test "should fulfill its contracts":

--- a/tests/boost/http/test_httpcommon.nim
+++ b/tests/boost/http/test_httpcommon.nim
@@ -1,4 +1,10 @@
-import boost.http.httpcommon, boost.data.props, unittest, strtabs, sequtils, asyncdispatch, boost.io.asyncstreams
+import boost/http/httpcommon,
+       boost/data/props,
+       unittest,
+       strtabs,
+       sequtils,
+       asyncdispatch,
+       boost/io/asyncstreams
 
 suite "HTTP utils":
   test "URL encode/decode":

--- a/tests/boost/http/test_httpcommon.nim
+++ b/tests/boost/http/test_httpcommon.nim
@@ -58,5 +58,5 @@ Content-Transfer-Encoding: binary
     ]
     # And now check that the stream is not corrupted
     check: not s.atEnd
-    check: (waitFor s.readLine) == ""
+    check: (waitFor s.readLine).len == 0
     check: s.atEnd

--- a/tests/boost/http/test_jester.nim
+++ b/tests/boost/http/test_jester.nim
@@ -1,11 +1,20 @@
 # Copyright (C) 2015 Dominik Picheta
 # MIT License - Look at license.txt for details.
-import boost.http.jester, asyncdispatch, strutils, random, os, asyncnet, re, threadpool, httpclient, unittest
+import boost/http/jester,
+       asyncdispatch,
+       strutils,
+       random,
+       os,
+       asyncnet,
+       re,
+       threadpool,
+       httpclient,
+       unittest
 
 const PORT = 9997.Port
 const HOST = "localhost"
 
-include impl.run_test_server
+include impl/run_test_server
 
 suite "Jester":
 

--- a/tests/boost/http/test_multipart.nim
+++ b/tests/boost/http/test_multipart.nim
@@ -1,8 +1,8 @@
-import boost.http.multipart,
-       boost.http.httpcommon,
+import boost/http/multipart,
+       boost/http/httpcommon,
        asyncdispatch,
-       boost.io.asyncstreams,
-       boost.data.props,
+       boost/io/asyncstreams,
+       boost/data/props,
        unittest,
        strutils
 

--- a/tests/boost/io/test_asyncstreams.nim
+++ b/tests/boost/io/test_asyncstreams.nim
@@ -1,4 +1,4 @@
-import boost.io.asyncstreams
+import boost/io/asyncstreams
 import unittest, asyncdispatch, asyncnet, threadpool, os, strutils
 
 const PORT = Port(9999)

--- a/tests/boost/io/test_asyncstreams.nim
+++ b/tests/boost/io/test_asyncstreams.nim
@@ -156,7 +156,7 @@ world!""")
       var res = newSeq[string]()
       while true:
         let l = await s.readLine()
-        if l == "":
+        if l.len == 0:
           break
         res.add(l)
       doAssert(res.join(", ") == "Hello, world!")
@@ -253,9 +253,9 @@ world!""")
       check: rd == "abcde"
 
       pd = await bs.peekLine
-      check: pd == ""
+      check: pd.len == 0
       
       rd = await bs.readLine
-      check: rd == ""
+      check: rd.len == 0
 
     waitFor doTest()

--- a/tests/boost/test_all.nim
+++ b/tests/boost/test_all.nim
@@ -7,9 +7,9 @@ when defined(js):
          test_richstring,
          test_typeutils
   # Data
-  import data.test_stackm,
-         data.test_rbtreem,
-         data.test_rbtree
+  import data/test_stackm,
+         data/test_rbtreem,
+         data/test_rbtree
          #TODO: https://github.com/vegansk/nimboost/issues/5
 else:
   # Core
@@ -20,23 +20,23 @@ else:
          test_richstring,
          test_typeutils
   # Data
-  import data.test_stackm,
-         data.test_rbtreem,
-         data.test_rbtree,
-         data.test_props,
-         data.test_memory
+  import data/test_stackm,
+         data/test_rbtreem,
+         data/test_rbtree,
+         data/test_props,
+         data/test_memory
 
   # HTTP - pure parts
   # asyncstreams test slows down execution for some reason (dispatcher?). So we
   # run "heavy" tests before that.
-  import http.test_httpcommon,
-         http.test_multipart,
-         http.test_asyncchunkedstream,
-         http.test_asynchttpserver_internals
+  import http/test_httpcommon,
+         http/test_multipart,
+         http/test_asyncchunkedstream,
+         http/test_asynchttpserver_internals
 
   # I/O
-  import io.test_asyncstreams
+  import io/test_asyncstreams
 
   # HTTP server
-  import http.test_asynchttpserver,
-         http.test_jester
+  import http/test_asynchttpserver,
+         http/test_jester

--- a/tests/boost/test_formatters.nim
+++ b/tests/boost/test_formatters.nim
@@ -1,4 +1,4 @@
-import boost.formatters,
+import boost/formatters,
        unittest
 
 suite "formatters":

--- a/tests/boost/test_limits.nim
+++ b/tests/boost/test_limits.nim
@@ -1,4 +1,4 @@
-import unittest, boost.limits, typetraits
+import unittest, boost/limits, typetraits
 
 # Workaround for https://github.com/nim-lang/Nim/issues/4714
 when defined(js):

--- a/tests/boost/test_parsers.nim
+++ b/tests/boost/test_parsers.nim
@@ -1,4 +1,4 @@
-import unittest, boost.parsers, boost.limits
+import unittest, boost/parsers, boost/limits
 
 from logging import nil
 

--- a/tests/boost/test_richstring.nim
+++ b/tests/boost/test_richstring.nim
@@ -1,6 +1,6 @@
-import boost.richstring,
+import boost/richstring,
        strutils,
-       boost.parsers,
+       boost/parsers,
        unittest
 
 {.warning[Deprecated]: off.}

--- a/tests/boost/test_typeclasses.nim
+++ b/tests/boost/test_typeclasses.nim
@@ -1,4 +1,4 @@
-import unittest, boost.typeclasses, typetraits
+import unittest, boost/typeclasses, typetraits
 
 # Needed for the ``check`` macro pretty print
 proc `$`(t: typedesc): auto = t.name

--- a/tests/boost/test_typeutils.nim
+++ b/tests/boost/test_typeutils.nim
@@ -1,5 +1,5 @@
-import boost.typeutils,
-       boost.jsonserialize,
+import boost/typeutils,
+       boost/jsonserialize,
        unittest,
        macros,
        ./test_typeutils_int,
@@ -427,7 +427,7 @@ suite "typeutils - data keyword":
 
     let j1 = x1.toJson
     check: j1["a"].getStr == "a"
-    check: j1["b"].getNum == 1
+    check: j1["b"].getInt == 1
 
     data TestAdt, json:
       Br1:
@@ -441,7 +441,7 @@ suite "typeutils - data keyword":
       discard fromJson(TestAdt, parseJson"""{ "A": "a", "B": 1 }""")
     let j2 = x2.toJson
     check: j2["kind"].getStr == "Br1"
-    check: j2["a"].getNum == 1
+    check: j2["a"].getInt == 1
 
   test "ADT with empty branch":
     data ADT, copy, eq, show, json:

--- a/tests/boost/test_typeutils_int.nim
+++ b/tests/boost/test_typeutils_int.nim
@@ -1,4 +1,4 @@
-import boost.typeutils
+import boost/typeutils
 
 type GlobalX* = object
   a*: int


### PR DESCRIPTION
This drops compatibility with Nim 0.18.0.

- Got rid of compilation errors and deprecation notices.
- Simplified `limits`.
- Updated `http/impl/patterns.nim` from Jester repo.

A pitfall: `rand` functions on ranges are not equivalent to similar `random` functions (the former are inclusive on the upper boundary).